### PR TITLE
capistrano-harrowのバージョンアップ

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-harrow (0.3.2)
+    capistrano-harrow (0.4.0)
     capistrano-rails (1.1.6)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -676,4 +676,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.1


### PR DESCRIPTION
capistrano-harrow (0.3.2) だとbundle install時にコケるようになってしまったので。
