### PR TITLE
kaminariテンプレートのescape対応

### DIFF
--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,2 +1,2 @@
 li
-  |  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %> 
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,11 +1,11 @@
 = paginator.render
 ul.pagination
-  = first_page_tag unless current_page.first?
-  = prev_page_tag unless current_page.first?
+  == first_page_tag unless current_page.first?
+  == prev_page_tag unless current_page.first?
   - each_page do |page|
     - if page.left_outer? || page.right_outer? || page.inside_window?
-      = page_tag page
+      == page_tag page
     - elsif !page.was_truncated?
-      = gap_tag
-  - next_page_tag unless current_page.last?
-  = last_page_tag unless current_page.last?
+      == gap_tag
+  == next_page_tag unless current_page.last?
+  == last_page_tag unless current_page.last?


### PR DESCRIPTION
## 概要

paginate() shows raw HTML with Slim template engine
https://github.com/kaminari/kaminari/issues/73

## 確認方法

- ページネーションがHTMLとして出力されるか
  - 現状だとページネーションのHTMLがそのまま出力されているはず

## 影響範囲

ページネーションまわり

## チェックリスト

- [ ] （masterブランチで）ページネーションのHTMLがエスケープされて表示されていることを確認
- [ ] （このPRのブランチで）ページネーションがHTMLとして出力されるか確認

## コメント

ちょっとはまってつかれた